### PR TITLE
Fixed state error when editing clue

### DIFF
--- a/src/components/clueForm/EditingClue.js
+++ b/src/components/clueForm/EditingClue.js
@@ -1,5 +1,5 @@
 
-export const ClueEditing = ({ currentClue, handleClueInput, clueTypes, editingClue, setEditing, saveStep }) => {
+export const ClueEditing = ({ currentClue,setCurrentClue, handleClueInput, clueTypes, editingClue, setEditing, saveStep }) => {
     // currentClue - state object
     // handleClueInput - function
     // clueTypes - state value
@@ -62,6 +62,7 @@ export const ClueEditing = ({ currentClue, handleClueInput, clueTypes, editingCl
                     onClick={(e) => {
                         e.preventDefault()
                         setEditing(!editingClue)
+                        setCurrentClue({ clueTypeId: 0 })
                     }
                     }>
                     Back


### PR DESCRIPTION
## Error
In EditingClue.js there was an error when a clue was selected for editing, and then the back button was clicked. State was not updated to reflect that the clue was no longer being edited.

## Fix
Added state update function to the back button function so the currentClue state is reset.