### PR TITLE
Fixed error with edit step button

### DIFF
--- a/src/components/huntCreator/HuntCreator.css
+++ b/src/components/huntCreator/HuntCreator.css
@@ -26,7 +26,7 @@
     display: flex;
     flex-direction: column;
     justify-content: space-between;
-    min-width: 70%;
+    width: 70%;
     text-align: center;
 }
 
@@ -75,4 +75,8 @@
 }
 .over {
     background-color: rgb(248, 216, 164);
+}
+
+.stepEdit, .stepDelete {
+    min-width: 4.5em;
 }

--- a/src/components/huntCreator/HuntCreator.js
+++ b/src/components/huntCreator/HuntCreator.js
@@ -181,18 +181,8 @@ export const HuntCreator = (props) => {
                 
             }
 
-            if (editingClue)
-             {
-                const clueJS = [<ClueEditing
-                    key={"clueEdit--0"}
-                    currentClue={currentClue}
-                    setCurrentClue={setCurrentClue}
-                    handleClueInput={handleClueInput}
-                    clueTypes={clueTypes}
-                    editingClue={editingClue}
-                    setEditing={setEditing}
-                    saveStep={saveStep} />]
-                setClueJSX(clueJS)
+            if (editingClue) {
+
             } else {
                 if (props.clues) {
                     const clueJS = props.clues.map((clue, index) => {
@@ -306,7 +296,19 @@ export const HuntCreator = (props) => {
                         </div>
                         <h3>Clues</h3>
                         <article className="stepList">
-                            {clueJSX}
+                            {
+                            editingClue
+                            ?   <ClueEditing
+                                key={"clueEdit--0"}
+                                currentClue={currentClue}
+                                setCurrentClue={setCurrentClue}
+                                handleClueInput={handleClueInput}
+                                clueTypes={clueTypes}
+                                editingClue={editingClue}
+                                setEditing={setEditing}
+                                saveStep={saveStep} />
+                            : clueJSX
+                            }
                         </article>
                     </div>
                     <div>


### PR DESCRIPTION
Edit button on hunt creator view did not properly send updated clue data to server.

Fixed by relocating the invocation of the saveStep function from the useEffect, because it is dependent on variables not included in the useEffect's dependencies.